### PR TITLE
halium-overlay: mtp-state.conf: Run setupusb through /bin/sh

### DIFF
--- a/halium-overlay/etc/init/mtp-state.conf
+++ b/halium-overlay/etc/init/mtp-state.conf
@@ -9,11 +9,11 @@ script
  VAL=$(getprop persist.sys.usb.config)
  case ${VAL} in
    mtp)
-     /system/halium/usr/share/usbinit/setupusb mtp
+     /bin/sh /system/halium/usr/share/usbinit/setupusb mtp
      /sbin/initctl emit android-mtp-on
      ;;
    mtp,adb)
-     /system/halium/usr/share/usbinit/setupusb mtp_adb
+     /bin/sh /system/halium/usr/share/usbinit/setupusb mtp_adb
      /sbin/initctl emit android-mtp-on
      ;;
    *)


### PR DESCRIPTION
The script placed on the overlay doesn't preserve execute bits.