### PR TITLE
WIP: halium-overlay: Add a workaround for Camera freezing

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -71,7 +71,9 @@ PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/halium-overlay/etc/pulse/touch-android9.pa:$(TARGET_COPY_OUT_SYSTEM)/halium/etc/pulse/touch-android9.pa \
     $(LOCAL_PATH)/halium-overlay/etc/ubuntu-touch-session.d/android.conf:$(TARGET_COPY_OUT_SYSTEM)/halium/etc/ubuntu-touch-session.d/android.conf \
     $(LOCAL_PATH)/halium-overlay/usr/share/upstart/sessions/mtp-server.conf:$(TARGET_COPY_OUT_SYSTEM)/halium/usr/share/upstart/sessions/mtp-server.conf \
-    $(LOCAL_PATH)/halium-overlay/usr/share/usbinit/setupusb:$(TARGET_COPY_OUT_SYSTEM)/halium/usr/share/usbinit/setupusb
+    $(LOCAL_PATH)/halium-overlay/usr/share/usbinit/setupusb:$(TARGET_COPY_OUT_SYSTEM)/halium/usr/share/usbinit/setupusb \
+    $(LOCAL_PATH)/halium-overlay/usr/share/upstart/sessions/cam-freeze-tmpfix.conf:$(TARGET_COPY_OUT_SYSTEM)/halium/usr/share/upstart/sessions/cam-freeze-tmpfix.conf \
+    $(LOCAL_PATH)/halium-overlay/etc/init/cam-freeze-tmpfix.conf:$(TARGET_COPY_OUT_SYSTEM)/halium/etc/init/cam-freeze-tmpfix.conf
 
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/halium-overlay/system/lib64/libtinyalsa.so:$(TARGET_COPY_OUT_SYSTEM)/halium/system/lib64/libtinyalsa.so \

--- a/halium-overlay/etc/init/cam-freeze-tmpfix.conf
+++ b/halium-overlay/etc/init/cam-freeze-tmpfix.conf
@@ -1,0 +1,1 @@
+/usr/share/upstart/sessions/cam-freeze-tmpfix.conf

--- a/halium-overlay/usr/share/upstart/sessions/cam-freeze-tmpfix.conf
+++ b/halium-overlay/usr/share/upstart/sessions/cam-freeze-tmpfix.conf
@@ -1,0 +1,13 @@
+description "Temporary fix for Camera freezing"
+start on started unity8
+stop on shutdown
+script
+    DIR="/home/phablet/.config/com.ubuntu.camera"
+    FILE="$DIR/com.ubuntu.camera.conf"
+    [ -e "$FILE" ] && exit 0
+    mkdir -p "$DIR"
+    cat > "$FILE" << EOF
+[General]
+photoResolutions=@Variant(\0\0\0\b\0\0\0\x1\0\0\0\x2\0\x30\0\0\0\n\0\0\0\x12\0\x34\0\x36\0\x30\0\x38\0x\0\x32\0\x35\0\x39\0\x32)
+EOF
+end script


### PR DESCRIPTION
The camera viewfinder freezes whenever switching between aspect ratios in any way (e.g. when switching from 4:3 photo mode to 16:9 video mode)

Since the Camera app defaults to the highest resolution which is a 4:3 aspect ratio one in photo mode, we'll just override it with the highest 16:9 aspect ratio one for now until a better fix is implemented elsewhere.