### PR TITLE
halium-overlay: mtp-state: Add hotfix for broken USB on recent images

### DIFF
--- a/halium-overlay/etc/init/mtp-state.conf
+++ b/halium-overlay/etc/init/mtp-state.conf
@@ -12,7 +12,7 @@ script
      /bin/sh /system/halium/usr/share/usbinit/setupusb mtp
      /sbin/initctl emit android-mtp-on
      ;;
-   mtp,adb)
+   *adb)
      /bin/sh /system/halium/usr/share/usbinit/setupusb mtp_adb
      /sbin/initctl emit android-mtp-on
      ;;


### PR DESCRIPTION
It seems when this service now starts initially the droid property `persist.sys.usb.config` now has a value of `adb` instead of `mtp,adb` like it did previously.