### PR TITLE
Be compatible with Focal's overlay & device-hacks system

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -7,5 +7,15 @@
 LOCAL_PATH := $(call my-dir)
 
 ifeq ($(TARGET_DEVICE),yggdrasil)
+
+# Make a symlink so that our built-from-source /system/lib/modules
+# overrides /vendor/lib/modules. Recipe thanks to Android's init.
+$(TARGET_OUT)/halium/vendor/lib/modules: $(LOCAL_PATH)/Android.mk
+	@echo "Symlink: $@ -> /system/lib/modules"
+	@mkdir -p $(dir $@)
+	@rm -rf $@
+	$(hide) ln -sf /system/lib/modules $@
+ALL_DEFAULT_INSTALLED_MODULES += $(TARGET_OUT)/halium/vendor/lib/modules
+
 include $(call all-makefiles-under,$(LOCAL_PATH))
 endif

--- a/device.mk
+++ b/device.mk
@@ -60,7 +60,6 @@ PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/halium-overlay/usr/share/upstart/sessions/audiosystem-passthrough.conf:$(TARGET_COPY_OUT_SYSTEM)/halium/usr/share/upstart/sessions/audiosystem-passthrough.conf \
     $(LOCAL_PATH)/halium-overlay/usr/sbin/mount-android.sh:$(TARGET_COPY_OUT_SYSTEM)/halium/usr/sbin/mount-android.sh \
     $(LOCAL_PATH)/halium-overlay/etc/init/aethercast.conf:$(TARGET_COPY_OUT_SYSTEM)/halium/etc/init/aethercast.conf \
-    $(LOCAL_PATH)/halium-overlay/etc/init/bluebinder.conf:$(TARGET_COPY_OUT_SYSTEM)/halium/etc/init/bluebinder.conf \
     $(LOCAL_PATH)/halium-overlay/etc/init/charger-reboot.conf:$(TARGET_COPY_OUT_SYSTEM)/halium/etc/init/charger-reboot.conf \
     $(LOCAL_PATH)/halium-overlay/etc/init/lxc-android-config.override:$(TARGET_COPY_OUT_SYSTEM)/halium/etc/init/lxc-android-config.override \
     $(LOCAL_PATH)/halium-overlay/etc/init/mount-android.conf:$(TARGET_COPY_OUT_SYSTEM)/halium/etc/init/mount-android.conf \
@@ -71,6 +70,7 @@ PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/halium-overlay/etc/ofono/main.conf:$(TARGET_COPY_OUT_SYSTEM)/halium/etc/ofono/main.conf \
     $(LOCAL_PATH)/halium-overlay/etc/ofono/ril_subscription.conf:$(TARGET_COPY_OUT_SYSTEM)/halium/etc/ofono/ril_subscription.conf \
     $(LOCAL_PATH)/halium-overlay/etc/ubuntu-touch-session.d/android.conf:$(TARGET_COPY_OUT_SYSTEM)/halium/etc/ubuntu-touch-session.d/android.conf \
+    $(LOCAL_PATH)/halium-overlay/usr/lib/lxc-android-config/device-hacks:$(TARGET_COPY_OUT_SYSTEM)/halium/usr/lib/lxc-android-config/device-hacks \
     $(LOCAL_PATH)/halium-overlay/usr/share/upstart/sessions/mtp-server.conf:$(TARGET_COPY_OUT_SYSTEM)/halium/usr/share/upstart/sessions/mtp-server.conf \
     $(LOCAL_PATH)/halium-overlay/usr/share/usbinit/setupusb:$(TARGET_COPY_OUT_SYSTEM)/halium/usr/share/usbinit/setupusb
 

--- a/device.mk
+++ b/device.mk
@@ -76,6 +76,7 @@ PRODUCT_COPY_FILES += \
 
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/halium-overlay/system/lib64/libtinyalsa.so:$(TARGET_COPY_OUT_SYSTEM)/halium/system/lib64/libtinyalsa.so \
+    $(LOCAL_PATH)/halium-overlay/vendor/.halium-overlay-dir:$(TARGET_COPY_OUT_SYSTEM)/halium/vendor/.halium-overlay-dir \
     $(LOCAL_PATH)/halium-overlay/vendor/lib/hw/audio.primary.mt6763.so:$(TARGET_COPY_OUT_SYSTEM)/halium/vendor/lib/hw/audio.primary.mt6763.so \
     $(LOCAL_PATH)/halium-overlay/vendor/lib64/hw/audio.primary.mt6763.so:$(TARGET_COPY_OUT_SYSTEM)/halium/vendor/lib64/hw/audio.primary.mt6763.so \
     $(LOCAL_PATH)/halium-overlay/vendor/lib64/libcam.halsensor.so:$(TARGET_COPY_OUT_SYSTEM)/halium/vendor/lib64/libcam.halsensor.so \

--- a/halium-overlay/usr/lib/lxc-android-config/device-hacks
+++ b/halium-overlay/usr/lib/lxc-android-config/device-hacks
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# This device has to be told when it's appropriate to start Wi-Fi. How it works
+# on Android, I'm not sure, but this is how it's done on many of MTK devices.
+
+while [ "$(getprop vendor.service.nvram_init)" != "Ready" ]; do
+    sleep 0.2
+done
+
+while [ ! -e /dev/wmtWifi ]; do
+    sleep 0.2
+done
+
+# Apparently solves some races preventing it from detecting 5GHz?
+sleep 2
+
+echo 1 > /dev/wmtWifi

--- a/halium-overlay/usr/sbin/mount-android.sh
+++ b/halium-overlay/usr/sbin/mount-android.sh
@@ -58,9 +58,6 @@ if [ -d "/opt/halium-overlay/system" ]; then
     mount -o bind /android/system /var/lib/lxc/android/rootfs/system
 fi
 
-# yggdrasil-specific overrides
-mount -o bind /system/lib/modules /vendor/lib/modules
-
 sys_persist="/sys/firmware/devicetree/base/firmware/android/fstab/persist"
 if [ -e $sys_persist ]; then
     label=$(cat $sys_persist/dev | awk -F/ '{print $NF}')


### PR DESCRIPTION
See [1] to understand how the new system work. Also, with the symlink,
the sepcial overlay in mount-android.sh is not needed, so it's removed.

At the moment, this is only minimal changes so that it boots and overlays are setup properly. More changes will be needed to fully support what's been previously supported.

[1] https://gitlab.com/ubports/core/hybris-support/lxc-android-config/-/merge_requests/52